### PR TITLE
Add env examples, MySQL migration SQL, and docker-compose MySQL defaults/healthcheck

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+MYSQL_ROOT_PASSWORD=password
+MYSQL_DATABASE=ai_app_square
+MYSQL_USER=ai_app_user
+MYSQL_PASSWORD=ai_app_password

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@
 
 ## 快速启动
 
+### 0) 准备本地环境变量
+
+```bash
+cp .env.example .env
+cp backend/.env.example backend/.env
+```
+
+> `.env` 提供 docker-compose MySQL 默认账号，`backend/.env` 控制后端数据库连接。
+
 ### 1) 后端
 
 ```bash
@@ -24,6 +33,12 @@ python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\Activate.ps1
 pip install -r requirements.txt
 uvicorn app.main:app --reload --port 8000
+```
+
+### 1.5) 使用 Docker Compose 启动 MySQL
+
+```bash
+docker compose up -d mysql
 ```
 
 ### 2) 前端
@@ -75,6 +90,10 @@ npm run dev
 | `rankings` | 应用榜单条目 | ranking_type/position/tag/score/likes/usage_30d/declared_at | 关联 `apps` |
 | `submissions` | 申报记录 | app_name/unit_name/contact/contact_phone/contact_email/category/scenario/cover_image_id/status/created_at | 与 `apps` 暂未强关联（申报通过后可转化为 `apps`） |
 | `submission_images` | 申报图片 | submission_id/image_url/thumbnail_url/original_name/file_size/is_cover | 关联 `submissions` |
+
+### migrations（SQL 快照）
+
+本仓库提供 `backend/migrations/001_init.sql`，用于初始化 MySQL 表结构（SQL 形式快照）。在本地快速验证可继续使用 SQLite + `Base.metadata.create_all` 的方式自动建表。若需使用 MySQL，可先执行该 SQL 文件再启动后端服务。
 
 ### 图片存储结构
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,5 @@
-# MySQL example:
-# DATABASE_URL=mysql+pymysql://root:password@127.0.0.1:3306/ai_app_square
+# MySQL example (aligns with docker-compose defaults):
+# DATABASE_URL=mysql+pymysql://ai_app_user:ai_app_password@127.0.0.1:3306/ai_app_square
 
 DATABASE_URL=sqlite:///./ai_app_square.db
 OA_RULE_BASE_URL=https://oa.example.internal

--- a/backend/migrations/001_init.sql
+++ b/backend/migrations/001_init.sql
@@ -1,0 +1,72 @@
+-- Initial schema for AI App Square (MySQL 8+)
+
+CREATE TABLE IF NOT EXISTS apps (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(120) NOT NULL,
+  org VARCHAR(60) NOT NULL,
+  section VARCHAR(20) NOT NULL,
+  category VARCHAR(30) NOT NULL,
+  description TEXT NOT NULL,
+  status VARCHAR(20) NOT NULL,
+  monthly_calls FLOAT NOT NULL,
+  release_date DATE NOT NULL,
+  api_open TINYINT(1) DEFAULT 0,
+  difficulty VARCHAR(20) DEFAULT 'Low',
+  contact_name VARCHAR(50) DEFAULT '',
+  highlight VARCHAR(200) DEFAULT '',
+  access_mode VARCHAR(20) DEFAULT 'direct',
+  access_url VARCHAR(255) DEFAULT '',
+  target_system VARCHAR(120) DEFAULT '',
+  target_users VARCHAR(120) DEFAULT '',
+  problem_statement VARCHAR(255) DEFAULT '',
+  effectiveness_type VARCHAR(40) DEFAULT 'cost_reduction',
+  effectiveness_metric VARCHAR(120) DEFAULT '',
+  cover_image_url VARCHAR(500) DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS rankings (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  ranking_type VARCHAR(20) NOT NULL,
+  position INT NOT NULL,
+  app_id INT NOT NULL,
+  tag VARCHAR(20) DEFAULT '推荐',
+  score INT DEFAULT 0,
+  likes INT DEFAULT NULL,
+  metric_type VARCHAR(20) DEFAULT 'composite',
+  value_dimension VARCHAR(40) DEFAULT 'cost_reduction',
+  usage_30d INT DEFAULT 0,
+  declared_at DATE NOT NULL,
+  CONSTRAINT fk_rankings_app FOREIGN KEY (app_id) REFERENCES apps(id)
+);
+
+CREATE TABLE IF NOT EXISTS submissions (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  app_name VARCHAR(120) NOT NULL,
+  unit_name VARCHAR(120) NOT NULL,
+  contact VARCHAR(80) NOT NULL,
+  contact_phone VARCHAR(20) DEFAULT '',
+  contact_email VARCHAR(120) DEFAULT '',
+  scenario VARCHAR(500) NOT NULL,
+  embedded_system VARCHAR(120) NOT NULL,
+  problem_statement VARCHAR(255) NOT NULL,
+  effectiveness_type VARCHAR(40) NOT NULL,
+  effectiveness_metric VARCHAR(120) NOT NULL,
+  data_level VARCHAR(10) NOT NULL,
+  expected_benefit VARCHAR(300) NOT NULL,
+  status VARCHAR(20) DEFAULT 'pending',
+  cover_image_id INT DEFAULT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS submission_images (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  submission_id INT NOT NULL,
+  image_url VARCHAR(500) NOT NULL,
+  thumbnail_url VARCHAR(500) DEFAULT '',
+  original_name VARCHAR(255) DEFAULT '',
+  file_size INT DEFAULT 0,
+  mime_type VARCHAR(50) DEFAULT '',
+  is_cover TINYINT(1) DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_submission_images_submission FOREIGN KEY (submission_id) REFERENCES submissions(id)
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,23 @@ version: '3.9'
 services:
   mysql:
     image: mysql:8.0
+    restart: unless-stopped
+    env_file:
+      - .env
     environment:
-      MYSQL_ROOT_PASSWORD: password
-      MYSQL_DATABASE: ai_app_square
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-password}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-ai_app_square}
+      MYSQL_USER: ${MYSQL_USER:-ai_app_user}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-ai_app_password}
     ports:
       - '3306:3306'
     volumes:
       - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-p${MYSQL_ROOT_PASSWORD:-password}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   mysql_data:


### PR DESCRIPTION
### Motivation

- Provide reproducible local MySQL defaults and make it easy to start the DB with `docker compose` by centralizing example credentials. 
- Offer a MySQL schema snapshot so teams can initialize a MySQL instance deterministically instead of relying only on SQLite auto-create. 
- Align documentation and backend env hints with the compose defaults so local setup instructions are consistent.

### Description

- Add a root `./.env.example` with MySQL credential defaults used by `docker-compose`. 
- Update `docker-compose.yml` to load `.env`, expose interpolated MySQL variables, add `restart: unless-stopped`, and a `healthcheck` for MySQL readiness. 
- Add `backend/migrations/001_init.sql` containing an initial MySQL-compatible schema snapshot for `apps`, `rankings`, `submissions`, and `submission_images`. 
- Update `backend/.env.example` to show a MySQL `DATABASE_URL` example that matches the compose defaults and update `README.md` with env preparation, `docker compose` usage, and a note about the migrations SQL snapshot.

### Testing

- No automated tests were run because the changes are documentation and configuration only. 
- Basic file presence/contents were inspected (`.env.example`, `docker-compose.yml`, `backend/migrations/001_init.sql`, `backend/.env.example`, `README.md`) and are present as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698969a1bc90833397b444882a8faa7a)