### PR TITLE
fix(models): align Date columns type hints with schemas

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -17,7 +17,7 @@ class App(Base):
     description: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(String(20), nullable=False)  # available | approval | beta | offline
     monthly_calls: Mapped[float] = mapped_column(Float, nullable=False)
-    release_date: Mapped[datetime] = mapped_column(Date, nullable=False)
+    release_date: Mapped[date] = mapped_column(Date, nullable=False)
     api_open: Mapped[bool] = mapped_column(Boolean, default=False)
     difficulty: Mapped[str] = mapped_column(String(20), default="Low")
     contact_name: Mapped[str] = mapped_column(String(50), default="")
@@ -62,7 +62,7 @@ class Ranking(Base):
     metric_type: Mapped[str] = mapped_column(String(20), default="composite")  # composite | growth_rate | likes
     value_dimension: Mapped[str] = mapped_column(String(40), default="cost_reduction")
     usage_30d: Mapped[int] = mapped_column(Integer, default=0)
-    declared_at: Mapped[datetime] = mapped_column(Date, nullable=False)
+    declared_at: Mapped[date] = mapped_column(Date, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     # 关联关系
     app = relationship("App", back_populates="rankings")

--- a/backend/tests/test_date_hints.py
+++ b/backend/tests/test_date_hints.py
@@ -1,0 +1,16 @@
+from datetime import date
+from typing import get_args
+
+from app import models
+
+
+def test_models_importable():
+    assert models is not None
+
+
+def test_date_hints_align_with_date_columns():
+    release_date_hint = models.App.__annotations__["release_date"]
+    declared_at_hint = models.Ranking.__annotations__["declared_at"]
+
+    assert date in get_args(release_date_hint)
+    assert date in get_args(declared_at_hint)


### PR DESCRIPTION
### Motivation
- Align Python type hints with the actual DB column types and schema expectations for date-only columns to avoid inconsistencies between models and schemas.

### Description
- Change `App.release_date` and `Ranking.declared_at` annotations from `Mapped[datetime]` to `Mapped[date]` in `backend/app/models.py`.
- Add a minimal regression test `backend/tests/test_date_hints.py` that imports `app.models` and asserts both annotations include `date`.
- Only `backend/app/models.py` was modified and `backend/tests/test_date_hints.py` was added; no DB migrations or API semantic changes were made.

### Testing
- Ran `cd backend && PYTHONPATH=. pytest -q tests/test_imports.py tests/test_api.py::test_health tests/test_date_hints.py` which completed with `4 passed` (warnings present but unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991f9461e508333aea213f4abd66847)