### PR TITLE
[codex] harden production backend install

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ ADMIN_DEFAULT_PASSWORD=ChangeMe_Admin_123!
 ```env
 PIP_INDEX_URL_PRODUCTION=http://136.142.12.68/simple/
 PIP_TRUSTED_HOST_PRODUCTION=136.142.12.68
+# PIP_USE_BUILD_ISOLATION=false
 ```
+
+生产部署默认关闭 editable install 的 build isolation，避免离线或仅内网主机在安装阶段再次向索引请求 `setuptools/wheel`。
 
 轻量安全基线：
 
@@ -126,6 +129,8 @@ make venv
 make backend-install
 make app-run
 ```
+
+如果远程机需要严格隔离构建，可在 `backend/.env` 里显式设置 `PIP_USE_BUILD_ISOLATION=true`；默认部署不需要打开。
 
 `make app-run` 会自动执行：
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,8 +11,12 @@ ENVIRONMENT=development
 
 # Python package installation source for production hosts.
 # Development keeps the default public PyPI behavior.
+# Production installs default to `--no-build-isolation` so offline/internal hosts
+# do not re-download setuptools/wheel during editable install.
+# Set PIP_USE_BUILD_ISOLATION=true only when you explicitly need isolated builds.
 PIP_INDEX_URL_PRODUCTION=http://136.142.12.68/simple/
 PIP_TRUSTED_HOST_PRODUCTION=136.142.12.68
+# PIP_USE_BUILD_ISOLATION=false
 
 # Host and ports
 APP_HOST=0.0.0.0

--- a/backend/scripts/dev/bootstrap_venv.sh
+++ b/backend/scripts/dev/bootstrap_venv.sh
@@ -33,14 +33,18 @@ if [[ ! -x "${VENV_PY}" ]]; then
 fi
 
 echo "[bootstrap] upgrading pip/setuptools/wheel"
-"${VENV_PY}" -m pip install "${PIP_INSTALL_ARGS[@]}" --upgrade pip "setuptools>=68" wheel
+ensure_python_packaging_tools "${VENV_PY}"
 
 echo "[bootstrap] installing requirements"
 "${VENV_PY}" -m pip install "${PIP_INSTALL_ARGS[@]}" -r requirements.txt
 
 echo "[bootstrap] installing editable package"
-if ! "${VENV_PY}" -m pip install "${PIP_INSTALL_ARGS[@]}" -e .; then
-  echo "[bootstrap] editable install with build isolation failed, retrying without build isolation"
+if use_build_isolation_for_editable_install; then
+  if ! "${VENV_PY}" -m pip install "${PIP_INSTALL_ARGS[@]}" -e .; then
+    echo "[bootstrap] editable install with build isolation failed, retrying without build isolation"
+    "${VENV_PY}" -m pip install "${PIP_INSTALL_ARGS[@]}" --no-build-isolation -e .
+  fi
+else
   "${VENV_PY}" -m pip install "${PIP_INSTALL_ARGS[@]}" --no-build-isolation -e .
 fi
 

--- a/scripts/backend_install.sh
+++ b/scripts/backend_install.sh
@@ -12,9 +12,13 @@ if [ ! -d "$VENV_DIR" ]; then
   python3 -m venv "$VENV_DIR"
 fi
 
-"$VENV_DIR/bin/pip" install "${PIP_INSTALL_ARGS[@]}" --upgrade pip "setuptools>=68" wheel
+ensure_python_packaging_tools "$VENV_DIR/bin/python"
 "$VENV_DIR/bin/pip" install "${PIP_INSTALL_ARGS[@]}" -r "$ROOT_DIR/backend/requirements.txt"
-if ! "$VENV_DIR/bin/pip" install "${PIP_INSTALL_ARGS[@]}" -e "$ROOT_DIR/backend"; then
-  echo "Editable install with build isolation failed; retrying without build isolation." >&2
+if use_build_isolation_for_editable_install; then
+  if ! "$VENV_DIR/bin/pip" install "${PIP_INSTALL_ARGS[@]}" -e "$ROOT_DIR/backend"; then
+    echo "Editable install with build isolation failed; retrying without build isolation." >&2
+    "$VENV_DIR/bin/pip" install "${PIP_INSTALL_ARGS[@]}" --no-build-isolation -e "$ROOT_DIR/backend"
+  fi
+else
   "$VENV_DIR/bin/pip" install "${PIP_INSTALL_ARGS[@]}" --no-build-isolation -e "$ROOT_DIR/backend"
 fi

--- a/scripts/load_pip_env.sh
+++ b/scripts/load_pip_env.sh
@@ -61,3 +61,71 @@ load_pip_install_args() {
       ;;
   esac
 }
+
+ensure_python_packaging_tools() {
+  local python_cmd="$1"
+  local -a packages_to_install=()
+  local package
+
+  while IFS= read -r package; do
+    [[ -n "$package" ]] && packages_to_install+=("$package")
+  done < <("$python_cmd" - <<'PY'
+import importlib.metadata as metadata
+
+required = []
+
+checks = (
+    ("pip", None),
+    ("setuptools", 68),
+    ("wheel", None),
+)
+
+for package_name, min_major in checks:
+    try:
+        version = metadata.version(package_name)
+    except metadata.PackageNotFoundError:
+        required.append(package_name if min_major is None else f"{package_name}>={min_major}")
+        continue
+
+    if min_major is None:
+        continue
+
+    try:
+        major = int(version.split(".", 1)[0])
+    except ValueError:
+        major = 0
+
+    if major < min_major:
+        required.append(f"{package_name}>={min_major}")
+
+for package in required:
+    print(package)
+PY
+)
+
+  if ((${#packages_to_install[@]} > 0)); then
+    "$python_cmd" -m pip install "${PIP_INSTALL_ARGS[@]}" --upgrade "${packages_to_install[@]}"
+  fi
+}
+
+use_build_isolation_for_editable_install() {
+  local environment="${ENVIRONMENT:-development}"
+  local override="${PIP_USE_BUILD_ISOLATION:-}"
+
+  if [[ -n "$override" ]]; then
+    case "$override" in
+      1|true|TRUE|yes|YES|on|ON)
+        return 0
+        ;;
+      0|false|FALSE|no|NO|off|OFF)
+        return 1
+        ;;
+      *)
+        echo "Unsupported PIP_USE_BUILD_ISOLATION='$override'. Expected true/false." >&2
+        exit 1
+        ;;
+    esac
+  fi
+
+  [[ "$environment" == "development" ]]
+}


### PR DESCRIPTION
This change hardens our backend install flow for production and internal deployment hosts.

In the deployment issue we traced, the immediate root cause was a remote `backend/.env` configured with `ENVIRONMENT=development`, which caused the install flow to skip the production pip mirror settings. Once that variable was corrected to `production`, the deployment succeeded. That means the environment setting was the direct fix for the outage.

The code changes in this PR are still useful as guardrails around that path. Today the install scripts always try to upgrade `pip`, `setuptools>=68`, and `wheel`, and editable installs attempt build isolation first. On internal or offline hosts, those behaviors can trigger noisy pip errors or unnecessary index lookups before the install eventually falls back. That makes the failure mode confusing and makes production deployments more brittle than they need to be.

This PR makes production-oriented install behavior more explicit:

- only install or upgrade packaging tools when the current virtualenv is actually missing them or has an insufficient setuptools major version
- default production installs to `--no-build-isolation`, while keeping development on the previous behavior
- allow an explicit `PIP_USE_BUILD_ISOLATION=true|false` override for hosts that need different behavior
- document the new production install expectation in `backend/.env.example` and the README

I validated the shell changes with:

- `bash -n scripts/load_pip_env.sh scripts/backend_install.sh backend/scripts/dev/bootstrap_venv.sh`
- a direct check that `ENVIRONMENT=production` disables build isolation by default
- a direct check that the packaging-tools helper runs cleanly against the repo virtualenv

This is meant as deployment hardening, not as a replacement for setting the correct `backend/.env` values on the target host.
