### PR TITLE
docs: consolidate documentation governance and agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,71 @@
+# AGENTS.md
+
+本文件是仓库级智能体工作契约，目标是让任意智能体工具进入仓库后，先理解项目、文档入口和文档维护规则，再进行修改。
+
+## 仓库速览
+
+- 项目：企业内部 AI 应用广场
+- 后端：FastAPI + SQLAlchemy ORM + Alembic
+- 数据库：MySQL 5.7
+- 前端：React + TypeScript + Vite
+- 运行方式：开发机构建前端静态产物，远程主机只负责运行发布物
+- 唯一应用配置源：`backend/.env`
+- 根目录 `.env`：仅用于 Docker Compose MySQL 覆盖，不是应用配置
+- 默认身份模式：`local`
+- 榜单参与与控制输入真相源：`AppRankingSetting`
+- 对外榜单读取真相源：`HistoricalRanking`
+
+## 文档真相源分层
+
+- 根 [README.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/README.md)
+  - 项目首页、最短入口、常用命令、文档导航
+- [docs/README.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/README.md)
+  - 当前有效文档索引和职责说明
+- [docs/GOVERNANCE.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/GOVERNANCE.md)
+  - 当前产品、数据、部署治理基线
+- [backend/scripts/README.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/backend/scripts/README.md)
+  - 仅解释脚本用途，不承担后端总文档角色
+- `docs/archive/`
+  - 历史审计、阶段性对齐稿、旧设计稿，仅供追溯，不作为当前规则入口
+
+## 智能体硬约束
+
+- 修改文档前，先判断现有主入口是否已经有对应真相源，禁止新建平行入口重复维护同类内容。
+- 涉及运行、部署、数据库、身份模式、榜单规则的改动时，必须同时检查：
+  - 根 `README.md` 是否仍是正确导航
+  - `docs/README.md` 是否仍准确描述职责
+  - `docs/GOVERNANCE.md` 是否需要同步治理结论
+- 新增文档时必须标注归属，只能归到以下之一：
+  - 主文档
+  - 专题文档
+  - 脚本说明
+  - 历史归档
+- 不额外制造“第二份 README”或“另一份当前规范”，尤其不要在 `backend/`、`docs/archive/` 或临时目录复制主入口内容。
+- 如果只是补充脚本说明、排障笔记或阶段记录，不要把它写成当前治理口径。
+- 文档中的命令和规则必须尽量单点维护；如果详细内容已经沉到 `docs/`，根 `README.md` 只保留短说明和跳转。
+
+## 最近关键文档变更
+
+- 最近一次文档治理收敛：2026-04-10
+- 当前有效入口：
+  - 根 `README.md`
+  - `docs/README.md`
+  - `docs/dev-setup.md`
+  - `docs/db-migration-sop.md`
+  - `docs/dev-workflow.md`
+  - `docs/GOVERNANCE.md`
+- 已明确不是当前规则入口：
+  - `docs/archive/*`
+  - `backend/scripts/README.md`
+  - 任何未在 `docs/README.md` 列出的临时说明文档
+- 当前治理结论：
+  - 根 `README.md` 保留总览和导航，不再承载完整运维细节
+  - `docs/README.md` 作为文档总索引
+  - `docs/GOVERNANCE.md` 只保留治理基线，不承担智能体操作规约
+
+## 文档维护动作
+
+- 修改主入口后，记得同步更新本文件里的“最近关键文档变更”。
+- 新增或重命名有效文档后，记得同步更新 `docs/README.md`。
+- 产品、部署、数据库、身份、榜单规则变化后，记得同步检查 `docs/GOVERNANCE.md`。
+- 如果某文档只剩历史价值，应迁入 `docs/archive/` 或在正文显式标注“仅供追溯”。

--- a/README.md
+++ b/README.md
@@ -1,76 +1,33 @@
 # AI-Platform-Square-HB
 
-企业内部 AI 应用广场，当前基线为：
+企业内部 AI 应用广场，当前基线：
 
 - 后端：FastAPI + SQLAlchemy ORM + Alembic
 - 数据库：MySQL 5.7
 - 前端：React + TypeScript + Vite
-- 部署：开发机构建前端静态产物，远程主机只负责运行
+- 部署：开发机构建前端静态产物，远程主机只负责运行发布物
 
 ## 当前产品口径
 
-- 首页对外聚焦：集团应用、省内应用、双榜单、申报入口。
+- 首页对外聚焦：集团应用、省内应用、双榜单、申报入口
 - 双榜单固定为：
   - `excellent`：总应用榜
   - `trend`：增长趋势榜
-- 默认系统榜单维度：
-  - 总应用榜：用户满意度、业务价值、使用活跃度、稳定性和安全性
-  - 增长趋势榜：使用活跃度、增长趋势、用户增长
-- 系统预置维度和系统榜单默认权重统一为 `1.0`。
-- 当前登录默认仍为本地账号；OA / 第三方统一登录采用预留模式，不在这一轮直接接真实系统。
+- 默认身份模式：`local`
+- 当前只做统一身份适配层预留，不直接接真实 OA / 第三方协议
+- 榜单参与与控制输入真相源：`AppRankingSetting`
+- 对外榜单读取真相源：`HistoricalRanking`
+
+更完整的治理结论见 [docs/GOVERNANCE.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/GOVERNANCE.md)。
 
 ## 环境文件
 
 应用只认一个运行时配置文件：
 
-- [backend/.env](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/backend/.env)：唯一应用配置源
-- [backend/.env.example](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/backend/.env.example)：模板
+- [backend/.env](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/backend/.env)
+- [backend/.env.example](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/backend/.env.example)
 
-根目录 `.env` 只给 Docker Compose MySQL 覆盖用，不要放应用配置。
-
-最关键配置项：
-
-```env
-DATABASE_URL=mysql+pymysql://ai_app_user:ai_app_password@127.0.0.1:13306/ai_app_square?charset=utf8mb4
-ENVIRONMENT=development
-
-APP_HOST=0.0.0.0
-APP_PORT=80
-BACKEND_DEV_PORT=8000
-FRONTEND_DEV_PORT=5173
-VITE_API_BASE_URL=http://127.0.0.1:8000
-
-AUTH_PROVIDER_MODE=local
-OA_SSO_LOGIN_URL=
-EXTERNAL_SSO_LOGIN_URL=
-ALLOWED_ORIGINS=http://127.0.0.1:5173,http://localhost:5173
-ALLOWED_HOSTS=127.0.0.1,localhost,testserver
-# AUTH_COOKIE_SECURE=false
-# ENABLE_API_DOCS=false
-
-USER_DEFAULT_PASSWORD=ChangeMe_User_123!
-ADMIN_DEFAULT_PASSWORD=ChangeMe_Admin_123!
-```
-
-生产环境后端依赖安装默认走内网 pip 源：
-
-```env
-PIP_INDEX_URL_PRODUCTION=http://136.142.12.68/simple/
-PIP_TRUSTED_HOST_PRODUCTION=136.142.12.68
-# PIP_USE_BUILD_ISOLATION=false
-```
-
-生产部署默认关闭 editable install 的 build isolation，避免离线或仅内网主机在安装阶段再次向索引请求 `setuptools/wheel`。
-
-轻量安全基线：
-
-- 前端默认只依赖 `HttpOnly` Cookie 会话，不再把登录 token 持久化到浏览器 `localStorage`
-- 生产环境默认关闭 API docs；只有显式设置 `ENABLE_API_DOCS=true` 才会开启
-- 生产环境请显式配置：
-  - `ALLOWED_ORIGINS`
-  - `ALLOWED_HOSTS`
-- 纯内网 HTTP 主机如暂时没有 HTTPS 终止层，可显式设置 `AUTH_COOKIE_SECURE=false`，避免生产环境 `Secure` Cookie 无法回传
-- 图片和文档上传默认要求已登录用户访问
+根目录 `.env` 只用于 Docker Compose MySQL 覆盖，不要放应用配置。
 
 ## 本地开发最短命令
 
@@ -102,184 +59,72 @@ make backend-dev
 make frontend-dev
 ```
 
-## 发布与远程部署
+完整开发说明见 [docs/dev-setup.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/dev-setup.md)。
 
-### 1. 开发机打包发布物
+## 发布与运维入口
+
+开发机打包发布物：
 
 ```bash
-git checkout main
-git pull origin main
-make frontend-install
 make frontend-build
 make release-bundle
 ```
 
-发布包会生成到 `release/`，其中已包含 `frontend/dist`。
-
-### 2. 远程主机部署
-
-远程主机不再需要 Node/npm，只需要 Python 3.10+、`make` 和数据库连通能力。
+远程主机启动：
 
 ```bash
-mkdir -p ~/AI-Platform-Square-HB
-cd ~/AI-Platform-Square-HB
-tar -xzf /上传路径/ai-platform-square-hb-*.tar.gz
-cp backend/.env.example backend/.env
 make venv
 make backend-install
 make app-run
 ```
 
-如果远程机需要严格隔离构建，可在 `backend/.env` 里显式设置 `PIP_USE_BUILD_ISOLATION=true`；默认部署不需要打开。
-
-`make app-run` 会自动执行：
-
-- 校验 `frontend/dist/index.html`
-- `alembic upgrade head`
-- `python -m app.bootstrap init-base`
-- 启动单端口服务
-
-健康检查：
-
-```bash
-curl http://127.0.0.1:${APP_PORT:-8080}/api/health
-```
-
-## 正式服务管理
-
-生产主机正式方案统一走 `systemd`，服务名默认是 `ai-platform-square`。
-
-安装服务：
+正式服务常用命令：
 
 ```bash
 make service-install
-```
-
-常用运维命令：
-
-```bash
 make service-start
-make service-stop
 make service-restart
 make service-status
 make service-logs
-make service-uninstall
 ```
 
-说明：
+详细发布流程见 [docs/dev-workflow.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/dev-workflow.md)。
 
-- `service-install` 会把 [ai-platform-square.service](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/deploy/systemd/ai-platform-square.service) 安装到 `/etc/systemd/system/`
-- `ExecStart` 最终执行的是 [app_run.sh](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/scripts/app_run.sh)
-- `nohup make app-run` 只建议用于临时排障
+## 数据库运维入口
 
-## 数据库运维口径
+当前正式命令只看这几类：
 
-当前数据库只支持三条正式运维路径：
+- 结构升级：`alembic upgrade head`
+- 基础初始化：`python -m app.bootstrap init-base`
+- 默认账号重置：`python -m app.bootstrap reset-default-users`
+- 系统预置同步：`python -m app.bootstrap sync-system-presets`
 
-### 1. 结构升级
+完整命令、顺序和适用场景见 [docs/db-migration-sop.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/db-migration-sop.md)。
 
-```bash
-cd backend
-PYTHONPATH=. ../.venv/bin/alembic upgrade head
-```
+## 当前文档治理状态
 
-### 2. 基础初始化
-
-```bash
-cd backend
-PYTHONPATH=. ../.venv/bin/python -m app.bootstrap init-base
-```
-
-用途：
-
-- 新库写入默认账号
-- 初始化系统维度
-- 初始化系统榜单配置
-
-`init-base` 是幂等的，但**不会覆盖**已有默认账号密码，也**不会覆盖**已有系统榜单预置。
-
-### 3. 默认账号重置
-
-```bash
-cd backend
-PYTHONPATH=. ../.venv/bin/python -m app.bootstrap reset-default-users
-```
-
-用途：
-
-- 显式重置 `zhangsan` / `lisi`
-- 当你修改了 `USER_DEFAULT_PASSWORD` / `ADMIN_DEFAULT_PASSWORD` 后，必须手工执行这条
-
-### 4. 系统预置同步
-
-```bash
-cd backend
-PYTHONPATH=. ../.venv/bin/python -m app.bootstrap sync-system-presets
-```
-
-用途：
-
-- 将系统内置维度和系统榜单配置同步到当前代码默认值
-- 会更新：
-  - 系统维度
-  - `excellent`
-  - `trend`
-- 不会碰：
-  - 自定义榜单
-  - 自定义维度
-  - 业务应用和榜单历史数据
-
-### 5. 高风险例外路径
-
-整库清空 / 整库重建不是常规运维命令，只能作为 DBA 或人工操作的例外方案。默认部署策略始终是“保留数据优先”。
-
-## 登录与身份模式
-
-身份模式通过 `AUTH_PROVIDER_MODE` 控制：
-
-- `local`：当前默认，本地账号登录
-- `oa`：预留 OA 统一登录入口
-- `external_sso`：预留第三方统一登录入口
-
-当前行为：
-
-- `local`：登录页显示用户名/密码表单
-- `oa` / `external_sso`：登录页切换为统一登录提示与外部入口按钮
-- 如果外部入口未配置，前后端都会返回明确的“未配置”提示，而不是半工作状态
-
-当前轮次只做架构预留，不直接打通 OA / 第三方协议。
-
-## 排障速记
-
-默认账号密码改了但登录不生效：
-
-```bash
-cd backend
-PYTHONPATH=. ../.venv/bin/python -m app.bootstrap reset-default-users
-```
-
-系统榜单、维度还是旧权重/旧名字：
-
-```bash
-cd backend
-PYTHONPATH=. ../.venv/bin/python -m app.bootstrap sync-system-presets
-```
-
-服务启动失败先看日志：
-
-```bash
-make service-logs
-```
-
-## 文档入口
-
-当前有效文档只看这几个：
+当前只认以下文档为有效入口：
 
 - [README.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/README.md)
+- [AGENTS.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/AGENTS.md)
 - [docs/README.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/README.md)
 - [docs/dev-setup.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/dev-setup.md)
 - [docs/db-migration-sop.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/db-migration-sop.md)
 - [docs/dev-workflow.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/dev-workflow.md)
 - [docs/GOVERNANCE.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/GOVERNANCE.md)
 
-历史审计、阶段性对齐稿和旧设计稿统一放到 `docs/archive/`，只用于追溯，不再作为主入口。
+以下内容仅供追溯，不作为当前规则入口：
+
+- `docs/archive/`
+- `backend/scripts/README.md`
+- 任何未在 `docs/README.md` 登记的临时说明文档
+
+## 给智能体的入口提示
+
+如果你是智能体工具，进入仓库后优先阅读：
+
+1. [AGENTS.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/AGENTS.md)
+2. [docs/README.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/README.md)
+3. [docs/GOVERNANCE.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/GOVERNANCE.md)
+
+不要从 `docs/archive/` 或脚本说明文档推断当前实现口径。

--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -1,5 +1,7 @@
 # Backend Scripts
 
+这里仅解释脚本用途，不是后端主入口，也不是当前治理规则入口。项目总览和有效文档入口请回到 [README.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/README.md) 与 [docs/README.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/README.md)。
+
 当前脚本集只保留 MySQL / ORM / 发布运行主链路相关工具。
 
 ## 运行与发布

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -37,3 +37,28 @@
   - `oa`
   - `external_sso`
 - 当前轮次只做统一身份适配层和登录入口预留，不直接接真实 OA / 第三方协议
+
+## 6. 文档治理规则
+
+- 根 `README.md` 只承担项目首页、最短入口和文档导航职责，不长期维护完整运维细节。
+- `docs/README.md` 是当前有效文档索引，新增、重命名或废弃有效文档时必须同步更新。
+- `AGENTS.md` 用于仓库级智能体工作约束、文档入口说明和最近关键文档变更摘要。
+- `backend/scripts/README.md` 只解释脚本用途，不承担后端主入口或治理结论职责。
+- `docs/archive/` 仅保留历史材料，不作为当前产品、部署或运维规则入口。
+
+## 7. 规则变化时的同步要求
+
+- 产品边界、榜单规则、数据真相源变化时，同步检查：
+  - `docs/GOVERNANCE.md`
+  - 根 `README.md`
+  - `docs/README.md`
+- 开发、部署、数据库命令变化时，同步检查：
+  - 根 `README.md`
+  - `docs/dev-setup.md`
+  - `docs/dev-workflow.md`
+  - `docs/db-migration-sop.md`
+  - `docs/README.md`
+- 文档入口或文档职责变化时，同步检查：
+  - `AGENTS.md`
+  - 根 `README.md`
+  - `docs/README.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,23 +1,41 @@
 # Docs Index
 
-## 当前有效文档
+本页是当前有效文档索引。需要修改规则、命令或治理结论时，先确认对应真相源，再修改正文。
+
+## 项目入口
 
 - [README.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/README.md)
-  - 项目总览、发布、部署、运维入口
+  - 项目首页，提供总览、最短启动和主文档跳转
+- [AGENTS.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/AGENTS.md)
+  - 仓库级智能体工作契约、文档分层和最近关键文档变更
+
+## 开发运行
+
 - [docs/dev-setup.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/dev-setup.md)
-  - 本地开发与最短命令清单
-- [docs/db-migration-sop.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/db-migration-sop.md)
-  - 数据库升级、基础初始化、密码重置、系统预置同步
+  - 本地开发环境、依赖准备、首次启动和日常命令
 - [docs/dev-workflow.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/dev-workflow.md)
-  - 分支、PR、发布包流程
+  - 分支、提交、PR、发布包与远程部署流程
+
+## 运维部署
+
+- [docs/db-migration-sop.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/db-migration-sop.md)
+  - 数据库升级、基础初始化、默认账号重置、系统预置同步
+- [backend/scripts/README.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/backend/scripts/README.md)
+  - 仅供查看脚本用途和脚本入口，不是当前治理或后端主入口
+
+## 治理规范
+
 - [docs/GOVERNANCE.md](/home/ctyun/BigData/GitHub/AI-Platform-Square-HB/docs/GOVERNANCE.md)
-  - 当前产品与治理基线
+  - 当前产品边界、榜单规则、数据真相源、部署与身份模式治理基线
 
 ## 历史归档
 
 - `docs/archive/`
-  - 历史审计稿
-  - 阶段性对齐记录
-  - 旧设计稿和阶段结项文档
+  - 历史审计稿、阶段性对齐记录、旧设计稿和阶段结项文档
+  - 仅用于追溯，不再作为当前实现或当前运维口径的主入口
 
-这些文件仅用于追溯，不再作为当前实现或当前运维口径的主入口。
+## 不要从哪里读当前规则
+
+- 不要从 `docs/archive/` 推断当前结论，那里的内容允许保留历史上下文。
+- 不要把 `backend/scripts/README.md` 视为后端总文档，它只解释脚本。
+- 不要从零散临时说明或未登记文档推断当前口径；若文档未列在本页，默认不是当前主入口。


### PR DESCRIPTION
## Summary
- add a repo-level `AGENTS.md` as the single agent-facing documentation contract
- slim down the root `README.md` into a project homepage and navigation entry
- formalize `docs/README.md` and `docs/GOVERNANCE.md` as the current document index and governance baseline
- clarify that `backend/scripts/README.md` is script-only documentation, not a backend source of truth

## Changes
- introduce document source-of-truth layering for humans and agent tools
- add a manually maintained "recent key documentation changes" section in `AGENTS.md`
- move repeated runtime and operations detail out of the root README and replace it with links to `docs/`
- add governance sync rules so product/runtime/database changes point back to the right docs
- mark `docs/archive/` and script docs as non-current reference material

## Validation
- checked link references among `README.md`, `AGENTS.md`, `docs/README.md`, and `docs/GOVERNANCE.md`
- verified the root README no longer carries the duplicated long-form operational detail already covered in `docs/`
- confirmed the working commit only includes the intended documentation files
