### PR TITLE
chore(ci): add playwright e2e discovery check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           python -m pytest -q tests
 
   frontend:
-    name: frontend (build)
+    name: frontend (build + e2e list)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -70,3 +70,7 @@ jobs:
       - name: Build (tsc + vite)
         run: |
           npm run build
+
+      - name: E2E smoke (discover tests only)
+        run: |
+          npm run test:e2e -- --list


### PR DESCRIPTION
## Summary
- keep CI change minimal
- extend frontend CI job with Playwright test discovery only

## Changes
- update frontend job name to: frontend (build + e2e list)
- after build, run:
  - npm run test:e2e -- --list

## Why
- validates Playwright config and test discovery without introducing browser runtime flakiness in CI
- provides low-risk guard for the newly added e2e suite

## Scope
- only .github/workflows/ci.yml