### PR TITLE
隔离集团应用封面上传并补齐录入体验

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,7 +11,7 @@ from threading import Lock
 from time import monotonic
 from typing import Optional
 
-from fastapi import Body, Cookie, Depends, FastAPI, File, Header, HTTPException, Query, Request, Response, UploadFile
+from fastapi import Body, Cookie, Depends, FastAPI, File, Form, Header, HTTPException, Query, Request, Response, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -3158,7 +3158,11 @@ def validate_document(file: UploadFile) -> tuple[bool, str]:
     return True, ""
 
 
-def save_image(file: UploadFile, submission_id: int | None = None) -> dict:
+def save_image(
+    file: UploadFile,
+    submission_id: int | None = None,
+    context: str = "submission",
+) -> dict:
     """Save image and create thumbnail"""
     # Generate unique filename
     ext = Path(file.filename).suffix.lower()
@@ -3166,11 +3170,17 @@ def save_image(file: UploadFile, submission_id: int | None = None) -> dict:
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     filename = f"{timestamp}_{unique_id}{ext}"
     
-    # Create directory structure
+    # Create directory structure. Context keeps submission and group-app uploads
+    # separated while preserving the same public response shape.
     if submission_id:
         save_dir = UPLOAD_DIR / "submissions" / str(submission_id)
+        url_prefix = f"submissions/{submission_id}"
+    elif context == "group_app":
+        save_dir = UPLOAD_DIR / "group-apps" / "temp"
+        url_prefix = "group-apps/temp"
     else:
-        save_dir = UPLOAD_DIR / "temp"
+        save_dir = UPLOAD_DIR / "submissions" / "temp"
+        url_prefix = "submissions/temp"
     save_dir.mkdir(parents=True, exist_ok=True)
     
     # Save original image
@@ -3200,12 +3210,8 @@ def save_image(file: UploadFile, submission_id: int | None = None) -> dict:
     
     # Generate URLs
     base_url = f"{settings.api_prefix}/static/uploads"
-    if submission_id:
-        image_url = f"{base_url}/submissions/{submission_id}/{filename}"
-        thumbnail_url = f"{base_url}/submissions/{submission_id}/{thumb_filename}"
-    else:
-        image_url = f"{base_url}/temp/{filename}"
-        thumbnail_url = f"{base_url}/temp/{thumb_filename}"
+    image_url = f"{base_url}/{url_prefix}/{filename}"
+    thumbnail_url = f"{base_url}/{url_prefix}/{thumb_filename}"
     
     return {
         "image_url": image_url,
@@ -3247,10 +3253,20 @@ def save_document(file: UploadFile) -> dict:
 async def upload_image(
     request: Request,
     file: UploadFile = File(...),
+    context: str = Form(default="submission"),
     _: AuthSession = Depends(require_submit_permission),
 ):
     """Upload image file"""
     enforce_rate_limit(request, bucket="upload_image", limit=20, window_seconds=300)
+    if context not in {"submission", "group_app"}:
+        return ImageUploadResponse(
+            success=False,
+            image_url="",
+            thumbnail_url="",
+            original_name=file.filename,
+            file_size=0,
+            message="无效的上传场景",
+        )
     # Validate file
     is_valid, error_msg = validate_image(file)
     if not is_valid:
@@ -3265,7 +3281,7 @@ async def upload_image(
     
     try:
         # Save image
-        result = save_image(file)
+        result = save_image(file, context=context)
         
         return ImageUploadResponse(
             success=True,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -556,7 +556,7 @@ function HomePage({
     setUploadProgress(0)
 
     try {
-      const result = await uploadImage(file)
+      const result = await uploadImage(file, 'submission')
       if (result.success) {
         setSubmission(prev => ({ ...prev, cover_image_url: result.image_url }))
         setUploadProgress(100)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -164,9 +164,13 @@ export async function withdrawMySubmission(submissionId: number) {
 }
 
 // Image upload API
-export async function uploadImage(file: File): Promise<ImageUploadResponse> {
+export async function uploadImage(
+  file: File,
+  context: 'submission' | 'group_app' = 'submission'
+): Promise<ImageUploadResponse> {
   const formData = new FormData()
   formData.append('file', file)
+  formData.append('context', context)
   
   const { data } = await client.post<ImageUploadResponse>(`${apiBasePath}/upload/image`, formData, {
     headers: {

--- a/frontend/src/components/UiIcon.tsx
+++ b/frontend/src/components/UiIcon.tsx
@@ -21,6 +21,7 @@ type UiIconName =
   | 'doc'
   | 'empty'
   | 'sync'
+  | 'upload'
 
 export default function UiIcon({ name, size = 16 }: { name: UiIconName; size?: number }) {
   const common = {
@@ -78,6 +79,8 @@ export default function UiIcon({ name, size = 16 }: { name: UiIconName; size?: n
       return <svg {...common}><path d="M7 3h8l4 4v14H7V3Z" /><path d="M15 3v4h4M10 12h6M10 16h6" /></svg>
     case 'sync':
       return <svg {...common}><path d="M20 7v5h-5" /><path d="M4 17v-5h5" /><path d="M6.5 9A7 7 0 0 1 18 7M17.5 15A7 7 0 0 1 6 17" /></svg>
+    case 'upload':
+      return <svg {...common}><path d="M12 16V4" /><path d="m7 9 5-5 5 5" /><path d="M5 20h14" /></svg>
     case 'empty':
       return <svg {...common}><path d="M4 19h16M6 17V7M12 17V4M18 17v-6" /></svg>
   }

--- a/frontend/src/pages/RankingManagementPage.tsx
+++ b/frontend/src/pages/RankingManagementPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import type { RankingConfigRecord, RankingDimension, AppItem } from '../types'
 import {
   fetchRankingDimensions,
@@ -19,11 +19,13 @@ import {
   createGroupApp,
   fetchAdminApps,
   updateAdminAppStatus,
+  uploadImage,
   isMissingAdminTokenError,
   getAdminTokenSetupHint
 } from '../api/client'
 import Pagination from '../components/Pagination'
 import { buildAppPath } from '../utils/basePath'
+import { resolveMediaUrl } from '../utils/media'
 import UiIcon from '../components/UiIcon'
 
 type RankingConfig = RankingConfigRecord
@@ -161,6 +163,9 @@ const RankingManagementPage = ({
   })
   const [groupAppSubmitting, setGroupAppSubmitting] = useState(false)
   const [groupAppMessage, setGroupAppMessage] = useState<string | null>(null)
+  const [groupImagePreview, setGroupImagePreview] = useState<string | null>(null)
+  const [groupImageUploading, setGroupImageUploading] = useState(false)
+  const [groupImageUploadProgress, setGroupImageUploadProgress] = useState(0)
   const [groupAppForm, setGroupAppForm] = useState({
     name: '',
     org: '',
@@ -606,7 +611,74 @@ const RankingManagementPage = ({
       effectiveness_metric: '',
       cover_image_url: ''
     })
+    setGroupImagePreview(null)
+    setGroupImageUploadProgress(0)
   }
+
+  const handleGroupImageUpload = useCallback(async (file: File) => {
+    const allowedTypes = ['image/jpeg', 'image/png', 'image/jpg']
+    if (!allowedTypes.includes(file.type)) {
+      setError('集团应用封面图仅支持 JPG、PNG 格式')
+      return
+    }
+
+    const maxSize = 5 * 1024 * 1024
+    if (file.size > maxSize) {
+      setError('集团应用封面图不能超过 5MB')
+      return
+    }
+
+    const reader = new FileReader()
+    reader.onload = (event) => {
+      setGroupImagePreview(event.target?.result as string)
+    }
+    reader.readAsDataURL(file)
+
+    setGroupImageUploading(true)
+    setGroupImageUploadProgress(0)
+    setError(null)
+    try {
+      const result = await uploadImage(file, 'group_app')
+      if (result.success) {
+        setGroupAppForm((prev) => ({ ...prev, cover_image_url: result.image_url }))
+        setGroupImageUploadProgress(100)
+      } else {
+        setError(result.message || '集团应用封面图上传失败')
+        setGroupImagePreview(null)
+      }
+    } catch (err) {
+      setError(resolveAdminError(err, '集团应用封面图上传失败'))
+      setGroupImagePreview(null)
+    } finally {
+      setGroupImageUploading(false)
+    }
+  }, [])
+
+  const handleGroupFileSelect = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (file) {
+      handleGroupImageUpload(file)
+    }
+    event.target.value = ''
+  }, [handleGroupImageUpload])
+
+  const handleGroupImageDrop = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    const file = event.dataTransfer.files?.[0]
+    if (file) {
+      handleGroupImageUpload(file)
+    }
+  }, [handleGroupImageUpload])
+
+  const handleGroupImageDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+  }, [])
+
+  const removeGroupImage = useCallback(() => {
+    setGroupImagePreview(null)
+    setGroupImageUploadProgress(0)
+    setGroupAppForm((prev) => ({ ...prev, cover_image_url: '' }))
+  }, [])
 
   const handleSaveGroupApp = async () => {
     if (categoryOptionsLoading || categoryOptionsError || appCategories.length === 0) {
@@ -1378,14 +1450,66 @@ const RankingManagementPage = ({
                     />
                   </div>
                   <div className="form-group">
-                    <label htmlFor="group-cover-url">封面图 URL</label>
-                    <input
-                      id="group-cover-url"
-                      type="text"
-                      value={groupAppForm.cover_image_url}
-                      onChange={(e) => setGroupAppForm(prev => ({ ...prev, cover_image_url: e.target.value }))}
-                    />
+                    <label>集团应用封面图</label>
+                    <div
+                      className={`group-image-upload-area ${(groupImagePreview || groupAppForm.cover_image_url) ? 'has-image' : ''}`}
+                      onDrop={handleGroupImageDrop}
+                      onDragOver={handleGroupImageDragOver}
+                    >
+                      {(groupImagePreview || groupAppForm.cover_image_url) ? (
+                        <div className="group-image-preview">
+                          <img
+                            src={groupImagePreview || resolveMediaUrl(groupAppForm.cover_image_url)}
+                            alt="集团应用封面预览"
+                          />
+                          <button
+                            type="button"
+                            className="remove-image"
+                            aria-label="移除集团应用封面图"
+                            onClick={(event) => {
+                              event.preventDefault()
+                              event.stopPropagation()
+                              removeGroupImage()
+                            }}
+                          >
+                            ×
+                          </button>
+                        </div>
+                      ) : (
+                        <div className="upload-placeholder">
+                          <div className="upload-icon"><UiIcon name="upload" /></div>
+                          <p>点击或拖拽上传封面图</p>
+                          <p className="upload-hint">集团应用图片保存到独立目录，支持 JPG、PNG，最大 5MB</p>
+                        </div>
+                      )}
+                      <input
+                        type="file"
+                        accept="image/jpeg,image/png,image/jpg"
+                        onChange={handleGroupFileSelect}
+                        className="file-input"
+                      />
+                      {groupImageUploading && (
+                        <div className="upload-progress">
+                          <div className="progress-bar" style={{ width: `${groupImageUploadProgress}%` }} />
+                        </div>
+                      )}
+                    </div>
                   </div>
+                </div>
+
+                <div className="form-group">
+                  <label htmlFor="group-cover-url">封面图 URL（可选兜底）</label>
+                  <input
+                    id="group-cover-url"
+                    type="text"
+                    value={groupAppForm.cover_image_url}
+                    onChange={(e) => {
+                      setGroupImagePreview(null)
+                      setGroupAppForm(prev => ({ ...prev, cover_image_url: e.target.value }))
+                    }}
+                    placeholder="上传成功后自动填充，也可粘贴已有图片地址"
+                  />
+                  <p className="form-hint">手填地址仅作为补录兜底；新上传图片会进入集团应用独立目录。</p>
                 </div>
               </form>
             </section>

--- a/frontend/src/styles/ranking-management.css
+++ b/frontend/src/styles/ranking-management.css
@@ -944,6 +944,110 @@ div.page.ranking-management-page div.page-content {
   width: auto;
 }
 
+.ranking-management-page .group-image-upload-area {
+  border: 2px dashed var(--border-color);
+  border-radius: var(--radius-md);
+  min-height: 180px;
+  padding: 24px;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.2s;
+  position: relative;
+  overflow: hidden;
+  background: var(--card-bg);
+}
+
+.ranking-management-page .group-image-upload-area:hover {
+  border-color: var(--primary-color);
+  background: rgba(79, 124, 255, 0.02);
+}
+
+.ranking-management-page .group-image-upload-area.has-image {
+  padding: 0;
+  border-style: solid;
+}
+
+.ranking-management-page .group-image-upload-area .upload-placeholder {
+  color: var(--text-muted);
+}
+
+.ranking-management-page .group-image-upload-area .upload-icon {
+  width: 40px;
+  height: 40px;
+  margin: 0 auto 10px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--primary-color);
+  background: rgba(79, 124, 255, 0.1);
+}
+
+.ranking-management-page .group-image-upload-area .upload-placeholder p {
+  margin: 4px 0;
+}
+
+.ranking-management-page .group-image-upload-area .upload-hint {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.ranking-management-page .group-image-preview {
+  position: relative;
+  z-index: 2;
+}
+
+.ranking-management-page .group-image-preview img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+}
+
+.ranking-management-page .group-image-upload-area .remove-image {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  border: 0;
+  cursor: pointer;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ranking-management-page .group-image-upload-area .file-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+  z-index: 1;
+}
+
+.ranking-management-page .group-image-upload-area.has-image .file-input {
+  pointer-events: none;
+}
+
+.ranking-management-page .group-image-upload-area .upload-progress {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 4px;
+  background: var(--border-color);
+}
+
+.ranking-management-page .group-image-upload-area .progress-bar {
+  height: 100%;
+  background: var(--primary-color);
+  transition: width 0.3s;
+}
+
 .ranking-management-page .dimension-score-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));


### PR DESCRIPTION
## What
- [x] 为封面图上传增加 submission / group_app 场景，按来源分目录保存。
- [x] 在集团应用录入页补齐封面图上传、预览、移除和上传进度。
- [x] 省内申报显式使用 submission 上传场景，集团应用显式使用 group_app 上传场景。

## Why
- [x] 集团应用录入需要仿照省内应用具备封面图上传能力，但不走申报审核链路。
- [x] 省内应用和集团应用封面图需要避免目录、表单状态和业务写入链路交叉污染。

## Changes
- [x] backend/app/main.py：上传接口新增 context 表单字段；图片按 uploads/submissions/temp 或 uploads/group-apps/temp 分目录保存。
- [x] frontend/src/api/client.ts / frontend/src/App.tsx：uploadImage 支持 context，省内申报传 submission。
- [x] frontend/src/pages/RankingManagementPage.tsx：集团应用录入新增独立上传状态和 UI，上传成功只写 groupAppForm.cover_image_url。
- [x] frontend/src/components/UiIcon.tsx / frontend/src/styles/ranking-management.css：新增上传图标和集团封面上传样式。

## How to verify
- [ ] 已跑 doctor：`make doctor`
- [ ] backend tests：`make backend-test`
- [x] frontend build：`make frontend-build`
- [x] 后端 API 定向测试：`../.venv/bin/python -m pytest tests/test_api.py -q`（62 passed）
- [x] 后端语法检查：`../.venv/bin/python -m py_compile app/main.py`
- [x] 若涉及 migrations：不涉及数据库迁移
- [x] 已检查 docs/README.md 和 docs/GOVERNANCE.md 是否需要同步：本次不改变治理口径，无需更新

## Definition of Done (DoD)
- [x] PR 描述已完整（What/Why/Changes/Verify）
- [x] 已自测：核心路径可用
- [x] 不引入无关重构/大范围格式化
- [x] 与 main 同步，无冲突（必要时 rebase）
- [ ] CI 全绿（Required checks 全通过）